### PR TITLE
 Associate labels with their inputs

### DIFF
--- a/application/views/csv2json_view.php
+++ b/application/views/csv2json_view.php
@@ -9,11 +9,11 @@
 	<div class="row gx-5">
 		<div class="col-md-5 mb-5">
 			<div class="mb-5">
-				<label class="form-label">Upload a CSV file</label>
+				<label for="fileupload" class="form-label">Upload a CSV file</label>
 				<input id="fileupload" type="file" name="file" class="form-control"/>
 			</div>
 			<div class="mb-3">
-				<label class="form-label">Or paste your CSV here</label>
+				<label for="csv" class="form-label">Or paste your CSV here</label>
 <textarea id="csv" class="form-control input save" rows="18" spellcheck="false">
 album, year, US_peak_chart_post
 The White Stripes, 1999, -
@@ -51,19 +51,19 @@ Nine Miles from the White City, 2013, -
 				</div>
 				<div class="form-check-inline">
 					<input type="checkbox" id="parseNumbers" name="parseNumbers" class="form-check-input save" checked="checked "/>
-					<label class="form-check-label" title="Check to parse numbers (i.e. '7e2' would become 700). Uncheck to keep original formatted numbers as strings.">
+					<label for="parseNumbers" class="form-check-label" title="Check to parse numbers (i.e. '7e2' would become 700). Uncheck to keep original formatted numbers as strings.">
 						 Parse numbers
 					</label>
 				</div>
 				<div class="form-check-inline">
 					<input type="checkbox" id="parseJSON" name="parseJSON" class="form-check-input save" checked="checked "/>
-					<label class="form-check-label" title="Check to parse potential values as JSON (numbers, null, false, true, [] and {}). Uncheck to keep original values as strings.">
+					<label for="parseJSON" class="form-check-label" title="Check to parse potential values as JSON (numbers, null, false, true, [] and {}). Uncheck to keep original values as strings.">
 						 Parse JSON
 					</label>
 				</div>
 				<div class="form-check-inline">
 					<input type="checkbox" id="transpose" name="transpose" class="form-check-input save" />
-					<label class="form-check-label" title="Transpose the data beforehand.">
+					<label for="transpose" class="form-check-label" title="Transpose the data beforehand.">
 						 Transpose
 					</label>
 				</div>
@@ -71,19 +71,19 @@ Nine Miles from the White City, 2013, -
 				<div class="form-check-inline">
 					<label class="form-check-label me-2">Output:</label>
 					<input type="radio" id="output-array" name="output" class="form-check-input save" value="array" checked="checked" />
-					<label class="form-check-label" title="Output an array of objects.">
+					<label for="output-array" class="form-check-label" title="Output an array of objects.">
 						Array
 					</label>
 				</div>
 				<div class="form-check-inline">
 					<input type="radio" id="output-hash" name="output" class="form-check-input save" value="hash" />
-					<label class="form-check-label" title="Output an object instead of an array. First column is used as hash key.">
+					<label for="output-hash" class="form-check-label" title="Output an object instead of an array. First column is used as hash key.">
 						Hash
 					</label>
 				</div>
 				<div class="form-check-inline">
 					<input type="checkbox" id="minify" name="minify" class="form-check-input save" />
-					<label class="form-check-label" title="Minify or compact result by removing spaces and new lines.">
+					<label for="minify" class="form-check-label" title="Minify or compact result by removing spaces and new lines.">
 						 Minify
 					</label>
 				</div>

--- a/application/views/csvjson2json_view.php
+++ b/application/views/csvjson2json_view.php
@@ -9,7 +9,7 @@
   <div class="row gx-5">
     <div class="col-md-5 mb-5">
       <div class="mb-5">
-        <label class="form-label">Upload a CSVJSON file</label>
+        <label for="fileupload" class="form-label">Upload a CSVJSON file</label>
           <input id="fileupload" type="file" name="file" class="form-control"/>
       </div>
       <div class="mb-3">
@@ -39,7 +39,7 @@
         <div class="mb-2">Options</div>
         <div class="form-check-inline pt-1">
           <input type="checkbox" id="minify" name="minify" class="form-check-input save" />
-          <label class="form-check-label" title="Minify or compact result by removing spaces and new lines.">
+          <label for="minify" class="form-check-label" title="Minify or compact result by removing spaces and new lines.">
              Minify
           </label>
         </div>

--- a/application/views/json_beautifier_view.php
+++ b/application/views/json_beautifier_view.php
@@ -8,11 +8,11 @@
 	<div class="row gx-5">
 		<div class="col-md-5 more-bottom-margin">
 			<div class="mb-5">
-				<label class="form-label">Upload a file</label>
+				<label for="fileupload" class="form-label">Upload a file</label>
 				<input id="fileupload" type="file" name="file" class="form-control"/>
 			</div>
 			<div class="form-group code-group">
-				<label class="form-label">Or paste your JSON here</label>
+				<label for="json" class="form-label">Or paste your JSON here</label>
 				<?php $default = '{"pi": "3.14159265359", "e": "2.7182818284", "prime": [2, 3, 5, 7, 11, 13, 17, 19], "1+6": 7}'; ?>
 				<div class="mb-3">
 					<textarea id="json" class="form-control input save" rows="18" placeholder="Paste your JSON here" spellcheck="false"><?=$default?></textarea>
@@ -56,7 +56,7 @@
 						<div class="">
 							<div class="form-check-inline">
 								<input type="checkbox" id="inline-short-arrays" name="inline-short-arrays" class="form-check-input save" />
-								<label class="form-label">Inline short arrays</label>
+								<label for="inline-short-arrays" class="form-label">Inline short arrays</label>
 						</div>
 						</div>
 						<select id="inline-short-arrays-depth" name="inline-short-arrays-depth" class="form-select save">
@@ -73,19 +73,19 @@
 				<div class="form-check-inline">
 					<label class="form-check-label me-2">No quotes:</label>
 					<input type="checkbox" id="drop-quotes-on-keys" name="drop-quotes-on-keys" class="form-check-input save" />
-					<label class="form-check-label" title="JSON wraps keys with double quotes by default. JavaScript doesn't need them though. Check this box to drop them. Will make for invalid JSON but valid JavaScript.">
+					<label for="drop-quotes-on-keys" class="form-check-label" title="JSON wraps keys with double quotes by default. JavaScript doesn't need them though. Check this box to drop them. Will make for invalid JSON but valid JavaScript.">
 						 on keys
 					</label>
 				</div>
 				<div class="form-check-inline">
 					<input type="checkbox" id="drop-quotes-on-numbers" name="drop-quotes-on-numbers" class="form-check-input save" />
-					<label class="form-check-label" title="Check this box to parse number values and drop quotes around them.">
+					<label for="drop-quotes-on-numbers" class="form-check-label" title="Check this box to parse number values and drop quotes around them.">
 						 on numbers
 					</label>
 				</div>
 				<div class="form-check-inline">
 					<input type="checkbox" id="minify" name="minify" class="form-check-input save" />
-					<label class="form-check-label" title="Minify or compact result by removing spaces and new lines. Warning: this overrides other options.">
+					<label for="minify" class="form-check-label" title="Minify or compact result by removing spaces and new lines. Warning: this overrides other options.">
 						 Minify
 					</label>
 				</div>

--- a/application/views/json_validator_view.php
+++ b/application/views/json_validator_view.php
@@ -10,12 +10,12 @@
   <div class="row gx-5">
     <div class="col-md-5 mb-5">
       <div class="mb-5">
-        <label class="form-label">Upload a file</label>
+        <label for="fileupload" class="form-label">Upload a file</label>
           <input id="fileupload" type="file" name="file" class="form-control"/>
       </div>
 
       <div class="mb-3">
-        <label class="form-label">Or paste your JSON here</label>
+        <label for="result" class="form-label">Or paste your JSON here</label>
 <textarea id="result" class="form-control result save" rows="14" placeholder="Paste your JSON here" spellcheck="false">{}</textarea>
       </div>
 
@@ -29,7 +29,7 @@
     </div>
     <div class="col-md-7">
       <div class="form-group">
-        <label class="form-label">Result</label>
+        <label for="status" class="form-label">Result</label>
         <div id="status" class="alert alert-default m-t-2"></div>
       </div>
     </div>

--- a/application/views/sql2json_view.php
+++ b/application/views/sql2json_view.php
@@ -9,7 +9,7 @@
 	<div class="row gx-5">
 		<div class="col-md-5 mb-5">
 			<div class="mb-5">
-				<label class="form-label">Upload a SQL file</label>
+				<label for="fileupload" class="form-label">Upload a SQL file</label>
 					<input id="fileupload" type="file" name="file"class="form-control" />
 			</div>
 			<div class="mb-3">
@@ -57,11 +57,11 @@ INSERT INTO `continents` VALUES ('??', NULL);
 				<div class="form-check-inline pt-1">
 					<label class="form-check-label me-2">Output format: </label>
 					<input type="radio" id="json" name="format" class="form-check-input save" value="json" checked="checked" />
-					<label class="form-check-label">JSON</label>
+					<label for="json" class="form-check-label">JSON</label>
 				</div>
 				<div class="form-check-inline">
 					<input type="radio" id="javascript" name="format" class="form-check-input save" value="javascript" />
-					<label class="form-check-label">JavaScript</label>
+					<label for="javascript" class="form-check-label">JavaScript</label>
 				</div>
 				<div class="form-check-inline">
 					<label class="form-check-label" title="Minify or compact result by removing spaces and new lines.">


### PR DESCRIPTION
For proper accessibility and good usability, [labels should be associated with their form controls][mdn labels].

This can be done with an explicit for attribute on the label with the same value as the form control's id attribute,
or by wrapping the label element around the form control. 
I opted to use the explicit method so as to not mess up any CSS layout being done.

I probably missed some edge cases relating to label/inputs dynamically loaded by JS but I think I got most of them.
In particular there were a couple labels for radio groups where legends/fieldsets should really be used. But that may be difficult to make work with your current CSS.

[mdn labels]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#:~:text=Associating%20a%20%3Clabel%3E%20with%20a%20form%20control